### PR TITLE
"Fixed" the SSL Problem

### DIFF
--- a/Services/FullContact.php
+++ b/Services/FullContact.php
@@ -109,6 +109,7 @@ class Services_FullContact
         $connection = curl_init($fullUrl);
         curl_setopt($connection, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($connection, CURLOPT_USERAGENT, self::USER_AGENT);
+        curl_setopt($connection, CURLOPT_SSL_VERIFYPEER, false);
 
         //execute request
         $this->response_json = curl_exec($connection);


### PR DESCRIPTION
The SDK was not working because of SSL problems.
I Just added the curl_setopt($connection, CURLOPT_SSL_VERIFYPEER, false); to temporary fix the problem.
It's necessary to fix the certificate validation to CURL